### PR TITLE
Build Python 3.13 wheels

### DIFF
--- a/.github/workflows/testing-and-deployment.yml
+++ b/.github/workflows/testing-and-deployment.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
         cache: pip
 
     - name: Install lsdyna-mesh-reader
@@ -55,7 +55,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Build wheels
-      uses: pypa/cibuildwheel@v2.19.2
+      uses: pypa/cibuildwheel@v2.22.0
 
     - uses: actions/upload-artifact@v4
       with:
@@ -70,7 +70,7 @@ jobs:
 
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.12'
+        python-version: '3.13'
 
     - name: Build sdist
       run: pipx run build --sdist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.6.3
+  rev: v0.8.0
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -32,7 +32,7 @@ repos:
     files: ^src/pyminiply/.*\.py
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.6.0
+  rev: v5.0.0
   hooks:
   - id: check-merge-conflict
   - id: debug-statements
@@ -40,7 +40,7 @@ repos:
     exclude: .*\.(cdb|k|dat)$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.11.2
+  rev: v1.13.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, npt-promote==0.1]
@@ -55,11 +55,11 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v17.0.6
+  rev: v19.1.4
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.2
+  rev: 0.29.4
   hooks:
   - id: check-github-workflows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12"
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
   "numpy>=1.22.4"
@@ -30,6 +31,7 @@ version = "0.2.dev0"
 
 [project.optional-dependencies]
 docs = ["pydata-sphinx-theme", "numpydoc", "sphinx", "sphinx-copybutton", "myst-parser"]
+pyvista = ["pyvista"]
 
 [project.urls]
 Documentation = "https://akaszynski.github.io/lsdyna-mesh-reader/"
@@ -37,7 +39,7 @@ Repository = "https://github.com/akaszynski/lsdyna-mesh-reader"
 
 [tool.cibuildwheel]
 archs = ["auto64"]  # 64-bit only
-skip = "cp38-* cp313-* pp* *musllinux*"  # 3.9-3.12 and no PyPy and musl-based wheels
+skip = "cp38-* cp314-* pp* *musllinux*"  # 3.9-3.13 and no PyPy and musl-based wheels
 test-command = "pytest {project}/tests -v"
 test-requires = "pytest pyvista"
 


### PR DESCRIPTION
Add support for Python 3.13.

Resolve #7 by adding pyvista in the `project.optional-dependencies`.
