### PR TITLE
Fix Python 3.13 release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ ci:
 
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.8.0
+  rev: v0.11.11
   hooks:
   - id: ruff
     args: [--fix, --exit-non-zero-on-fix]
@@ -19,7 +19,7 @@ repos:
     exclude: README.rst
 
 - repo: https://github.com/codespell-project/codespell
-  rev: v2.3.0
+  rev: v2.4.1
   hooks:
   - id: codespell
     args: [--skip=*.vt*]
@@ -40,7 +40,7 @@ repos:
     exclude: .*\.(cdb|k|dat)$
 
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.13.0
+  rev: v1.15.0
   hooks:
   - id: mypy
     additional_dependencies: [numpy>=2.0, npt-promote==0.1]
@@ -55,11 +55,11 @@ repos:
     args: [--autofix, --indent, '2']
 
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v19.1.4
+  rev: v20.1.5
   hooks:
   - id: clang-format
 
 - repo: https://github.com/python-jsonschema/check-jsonschema
-  rev: 0.29.4
+  rev: 0.33.0
   hooks:
   - id: check-github-workflows


### PR DESCRIPTION
Just noticed we're missing wheels for Python 3.13. Fixing that by simply rerunning the CI. Since pre-commit needs to be updated, we can kill two birds with one stone by updating that, triggering a build, and then pushing a release through.

Also bumps https://github.com/pypa/cibuildwheel.